### PR TITLE
Fix warning ios with latest react native version

### DIFF
--- a/ios/KustomerSDK.m
+++ b/ios/KustomerSDK.m
@@ -2,6 +2,10 @@
 
 @interface RCT_EXTERN_MODULE(KustomerSDK, NSObject)
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 RCT_EXTERN_METHOD(identify: (NSString*)hash
                    resolver:(RCTPromiseResolveBlock)resolve
                    rejecter:(RCTPromiseRejectBlock)reject


### PR DESCRIPTION
This PR fixes this warning:

WARN Module KustomerSDK requires main queue setup since it overrides init but doesn't implement requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.